### PR TITLE
[Signs] Fix text Z-Fighting

### DIFF
--- a/src/toontown/dna/dnaSign.cxx
+++ b/src/toontown/dna/dnaSign.cxx
@@ -78,9 +78,7 @@ NodePath DNASign::traverse(NodePath &parent, DNAStorage *store, int editing) {
     sign_node_path = building_front.attach_new_node(new ModelNode("sign"));
   }
   nassertr(!sign_node_path.is_empty(), parent);
-
-  // Turn off the writing of z-buffer information:
-  sign_node_path.set_depth_write(0);
+  
   //sign_node_path.node()->set_name("sign");
 
   // The Sign_origin is a special node in the model with a local

--- a/src/toontown/dna/dnaSignBaseline.cxx
+++ b/src/toontown/dna/dnaSignBaseline.cxx
@@ -323,6 +323,8 @@ void DNASignBaseline::center(LVector3f &pos, LVector3f &hpr) {
     pos[0] -= radius*cos_ang;
     pos[2] -= radius*sin_ang;
   }
+  // Fix for modern Panda's text rendering
+  pos[1] = -0.05;
 }
 
 


### PR DESCRIPTION
Modern panda renders text a bit differently, so we need to adjust to prevent z-fighting with the sign background