### PR TITLE
Set _nametag2d and _nametag3d in NametagGroup as pointers

### DIFF
--- a/src/otp/nametag/nametagGroup.h
+++ b/src/otp/nametag/nametagGroup.h
@@ -150,8 +150,8 @@ public:
 private:
   void update_contents_all();
 
-  Nametag2d *_nametag2d;
-  Nametag3d *_nametag3d;
+  PT(Nametag2d) _nametag2d;
+  PT(Nametag3d) _nametag3d;
 
   typedef pvector<Nametag*> Nametags;
   Nametags _nametags;


### PR DESCRIPTION
This PR resolves issue #4 where `getNametag2d` and `getNametag3d` calls would deconstruct the two variables when being garbage collected by Python.  